### PR TITLE
Making ax parameter not necessary

### DIFF
--- a/prettierplot/cat.py
+++ b/prettierplot/cat.py
@@ -44,6 +44,9 @@ def bar_v(self, x, counts, color=style.style_grey, x_labels=None, x_tick_wrap=Fa
             ax : axes object, default=None
                 Axis on which to place visual.
     """
+    if ax is None:
+        ax = self.ax
+
     # custom labels
     labels = x_labels if x_labels is not None else x
 
@@ -119,7 +122,10 @@ def bar_h(self, y, counts, color=style.style_grey, label_rotate=45, x_units="f",
             ax : axes object, default=None
                 Axis on which to place visual.
     """
+    if ax is None:
+        ax = self.ax
     # plot horizontal bar plot
+
     plt.barh(y=y, width=counts, color=color, tick_label=y, alpha=alpha)
 
     # rotate x-tick labels
@@ -135,6 +141,7 @@ def bar_h(self, y, counts, color=style.style_grey, label_rotate=45, x_units="f",
 
     # use label formatter utility function to customize chart labels
     util.util_label_formatter(ax=ax, x_units=x_units)
+
 
 def stacked_bar_h(self, df, label_rotate=0, x_units="p", alpha=0.8, color_map="viridis", bbox=(1.2,0.9),
                     legend_labels=None, ax=None):
@@ -166,6 +173,8 @@ def stacked_bar_h(self, df, label_rotate=0, x_units="p", alpha=0.8, color_map="v
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
 
     # define class label count and bar color list
     y = np.arange(len(df.index))
@@ -294,6 +303,9 @@ def box_plot_v(self, x, y, data, color, label_rotate=0, y_units="f", color_map="
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
+
     # create vertical box plot.
     g = sns.boxplot(
         x=x,
@@ -338,6 +350,7 @@ def box_plot_v(self, x, y, data, color, label_rotate=0, y_units="f", color_map="
     # use label formatter utility function to customize chart labels
     util.util_label_formatter(ax=ax, y_units=y_units)
 
+
 def box_plot_h(self, x, y, data, color=style.style_grey, x_units="f", bbox=(1.05, 1), color_map="viridis",
                         suppress_outliers=False, alpha=0.8, legend_labels=None, ax=None):
     """
@@ -377,7 +390,10 @@ def box_plot_h(self, x, y, data, color=style.style_grey, x_units="f", bbox=(1.05
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
     # create horizontal box plot
+
     g = sns.boxplot(
         x=x,
         y=y,
@@ -454,6 +470,9 @@ def tree_map(self, counts, labels, colors, alpha=0.8, ax=None):
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
+
     # draw treemap plot
     squarify.plot(
         sizes=counts,

--- a/prettierplot/facet.py
+++ b/prettierplot/facet.py
@@ -46,6 +46,9 @@ def facet_cat(self, df, feature, label_rotate=0, x_units="s", y_units="f", bbox=
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
+
     ixs = np.arange(df.shape[0])
     bar_width = 0.35
 
@@ -171,6 +174,9 @@ def facet_two_cat_bar(self, df, x, y, split, x_units=None, y_units=None, bbox=No
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
+
     # remove nans from x columns
     if filter_nan:
         df = df.dropna(subset=[x])

--- a/prettierplot/line.py
+++ b/prettierplot/line.py
@@ -55,6 +55,9 @@ def line(self, x, y, label=None, df=None, linecolor=style.style_grey, linestyle=
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
+
     # if a Pandas DataFrame is passed to function, create x and y arrays using columns names passed into function
     if df is not None:
         if isinstance(df.index, pd.core.indexes.base.Index):
@@ -184,6 +187,9 @@ def multi_line(self, x, y, label=None, df=None, linecolor=None, linestyle=None, 
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
+
     # if a Pandas DataFrame is passed to function, create x and y arrays using columns names passed into function
     if df is not None:
         if isinstance(df.index, pd.core.indexes.base.Index):

--- a/prettierplot/num.py
+++ b/prettierplot/num.py
@@ -61,6 +61,9 @@ def scatter_2d(self, x, y, df=None, x_units="f", x_ticks=None, y_units="f", y_ti
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
+
     # if a Pandas DataFrame is passed to function, create x and y arrays using columns names passed into function
     if df is not None:
         x = df[x].values.reshape(-1, 1)
@@ -173,6 +176,9 @@ def scatter_2d_hue(self, x, y, target, label, df=None, x_units="f", x_ticks=None
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
+
     # if a Pandas DataFrame is passed to function, create x and y and target arrays using columns names
     # passed into function. Also concatenates columns into single object
     if df is not None:
@@ -291,6 +297,9 @@ def dist_plot(self, x, color, x_units="f", y_units="f", fit=None, kde=False, x_r
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
+
     # create distribution plot with an optional fit curve
     g = sns.distplot(
         a=x,
@@ -387,6 +396,9 @@ def kde_plot(self, x, color, x_units="f", y_units="f", shade=False, line_width=0
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
+
     # create kernel density estimation line
     g = sns.kdeplot(
         data=x,
@@ -457,6 +469,9 @@ def reg_plot(self, x, y, data, dot_color=style.style_grey, dot_size=2.0, line_co
             ax : axes object, default=None
                 Axis object for the visualization.
     """
+    if ax is None:
+        ax = self.ax
+
     # create regression plot
     g = sns.regplot(
         x=x,

--- a/prettierplot/plotter.py
+++ b/prettierplot/plotter.py
@@ -195,4 +195,6 @@ class PrettierPlot:
             horizontalalignment="left",
         )
 
+        self.ax = ax
+
         return ax

--- a/prettierplot/style.py
+++ b/prettierplot/style.py
@@ -15,6 +15,7 @@ def color_gen(name="viridis", num=2):
         Parameters:
             name: str, default="viridis"
                 Name of built-in colormap
+                List of available colormaps: https://matplotlib.org/tutorials/colors/colormaps.html
             num : int, default=2
                 An integer specifying the number of colors to retrieve from colormap.
 


### PR DESCRIPTION
The ax parameter in every function seemed redundant.

Point of the PR is to be able to write this (with no loss of functionality, ax can still be used if desired):

```
# create Axes object and decorate
p.make_canvas(title="Educational field category counts", y_label="Category counts", y_shift=0.47)

# add plots
p.bar_v(
    x=unique_vals,
    counts=unique_counts,
    label_rotate=45,
    x_tick_wrap=True
)
```